### PR TITLE
feat: switch host to angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ This repository contains planning and documentation for building a TikTok-like s
 
 The documentation covers the product requirements, development plan, proposed technology stack, and monorepo project structure.
 
+## Monorepo Structure
+
+- `apps/host` – Angular host application configured with Webpack 5 Module Federation and Angular Router to load remote modules.
+- `packages/ui-kit` – Shared Angular UI component library exposing a styled `Button` component.
+
 ## Documentation
 - [Product Requirements and Technical Plan](docs/PRD.md)
 
 ## Status
-Planning phase only. Code implementation will be added in subsequent commits.
+Initial workspace setup with an Angular host and shared UI kit.

--- a/apps/host/package.json
+++ b/apps/host/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "host",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "@short-video/ui-kit": "workspace:*"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/host/src/app/app.component.ts
+++ b/apps/host/src/app/app.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <header>
+      <h1>Host App</h1>
+      <sv-button (clicked)="onShared()">Shared Button</sv-button>
+      <nav>
+        <a routerLink="/">Home</a> |
+        <a routerLink="/remote">Remote</a>
+      </nav>
+    </header>
+    <router-outlet></router-outlet>
+  `
+})
+export class AppComponent {
+  onShared() {
+    alert('Shared Button');
+  }
+}

--- a/apps/host/src/app/app.module.ts
+++ b/apps/host/src/app/app.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule, Routes } from '@angular/router';
+import { AppComponent } from './app.component';
+import { UiKitModule } from '@short-video/ui-kit';
+
+const routes: Routes = [
+  { path: '', component: AppComponent },
+  {
+    path: 'remote',
+    loadChildren: () => import('remote/Module').then(m => m.RemoteModule)
+  }
+];
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, UiKitModule, RouterModule.forRoot(routes)],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/apps/host/src/bootstrap.ts
+++ b/apps/host/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/apps/host/src/index.html
+++ b/apps/host/src/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Host App</title>
+    <base href="/">
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -1,0 +1,1 @@
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/host/tsconfig.json
+++ b/apps/host/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/host/webpack.config.js
+++ b/apps/host/webpack.config.js
@@ -1,0 +1,46 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  output: {
+    publicPath: 'auto',
+    path: path.resolve(__dirname, 'dist')
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      remotes: {
+        remote: 'remote@http://localhost:3001/remoteEntry.js'
+      },
+      shared: {
+        '@angular/core': { singleton: true, strictVersion: true },
+        '@angular/common': { singleton: true, strictVersion: true },
+        '@angular/router': { singleton: true, strictVersion: true }
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ],
+  devServer: {
+    port: 4200,
+    historyApiFallback: true
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "short-video",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Monorepo for micro frontends",
+  "scripts": {
+    "build": "pnpm -r build",
+    "start": "pnpm --filter host start"
+  }
+}

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@short-video/ui-kit",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "peerDependencies": {
+    "@angular/core": "^16.0.0",
+    "@angular/common": "^16.0.0"
+  }
+}

--- a/packages/ui-kit/src/button.component.ts
+++ b/packages/ui-kit/src/button.component.ts
@@ -1,0 +1,13 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+
+@Component({
+  selector: 'sv-button',
+  template: `<button class="ui-button" (click)="handleClick($event)"><ng-content></ng-content></button>`,
+  styleUrls: ['./button.css']
+})
+export class ButtonComponent {
+  @Output() clicked = new EventEmitter<Event>();
+  handleClick(event: Event) {
+    this.clicked.emit(event);
+  }
+}

--- a/packages/ui-kit/src/button.css
+++ b/packages/ui-kit/src/button.css
@@ -1,0 +1,8 @@
+.ui-button {
+  padding: 8px 16px;
+  background: #6200ea;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,0 +1,2 @@
+export * from './button.component';
+export * from './ui-kit.module';

--- a/packages/ui-kit/src/ui-kit.module.ts
+++ b/packages/ui-kit/src/ui-kit.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from './button.component';
+
+@NgModule({
+  declarations: [ButtonComponent],
+  imports: [CommonModule],
+  exports: [ButtonComponent]
+})
+export class UiKitModule {}

--- a/packages/ui-kit/tsconfig.json
+++ b/packages/ui-kit/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/index.ts"],
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- replace React host with Angular host configured with Webpack 5 Module Federation and router
- convert shared ui-kit package into Angular module providing a styled button

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -r build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b49321cdac8323a800acd2fcf3700e