### PR TITLE
feat: add angular feed micro frontend

### DIFF
--- a/apps/feed/package.json
+++ b/apps/feed/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "feed",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "@short-video/event-bus": "workspace:*"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/feed/src/app/feed.component.ts
+++ b/apps/feed/src/app/feed.component.ts
@@ -1,0 +1,60 @@
+import { Component, AfterViewInit, ViewChildren, ElementRef, QueryList, HostListener } from '@angular/core';
+import { VideoService, Video } from './video.service';
+import { eventBus, EVENTS } from '@short-video/event-bus';
+
+@Component({
+  selector: 'app-feed',
+  template: `
+    <div class="video" *ngFor="let video of videos" #videoRef [attr.data-id]="video.id">
+      <h3>{{video.title}}</h3>
+      <video width="320" height="240" controls [src]="video.src"></video>
+    </div>
+    <div *ngIf="loading" class="loading">Loading...</div>
+  `,
+  styles: ['.video{margin-bottom:24px;}']
+})
+export class FeedComponent implements AfterViewInit {
+  videos: Video[] = [];
+  private page = 0;
+  loading = false;
+  @ViewChildren('videoRef') videoRefs!: QueryList<ElementRef>;
+
+  constructor(private videoService: VideoService) {}
+
+  ngOnInit() {
+    this.loadMore();
+  }
+
+  ngAfterViewInit() {
+    this.observeVideos();
+    this.videoRefs.changes.subscribe(() => this.observeVideos());
+  }
+
+  observeVideos() {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const id = Number((entry.target as HTMLElement).dataset['id']);
+          eventBus.emit(EVENTS.VIDEO_VIEWED, { id });
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.5 });
+    this.videoRefs.forEach(ref => observer.observe(ref.nativeElement));
+  }
+
+  @HostListener('window:scroll', [])
+  onScroll() {
+    if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 2 && !this.loading) {
+      this.loadMore();
+    }
+  }
+
+  private loadMore() {
+    this.loading = true;
+    this.videoService.getVideos(this.page++).then(newVideos => {
+      this.videos = this.videos.concat(newVideos);
+      this.loading = false;
+    });
+  }
+}

--- a/apps/feed/src/app/feed.module.ts
+++ b/apps/feed/src/app/feed.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FeedComponent } from './feed.component';
+
+@NgModule({
+  declarations: [FeedComponent],
+  imports: [BrowserModule],
+  exports: [FeedComponent]
+})
+export class FeedModule {}

--- a/apps/feed/src/app/video.service.ts
+++ b/apps/feed/src/app/video.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+export interface Video {
+  id: number;
+  title: string;
+  src: string;
+}
+
+const MOCK_VIDEOS: Video[] = Array.from({ length: 100 }).map((_, i) => ({
+  id: i + 1,
+  title: `Video ${i + 1}`,
+  src: `https://placehold.co/320x240?text=Video+${i + 1}`
+}));
+
+@Injectable({ providedIn: 'root' })
+export class VideoService {
+  private pageSize = 10;
+
+  async getVideos(page: number): Promise<Video[]> {
+    const start = page * this.pageSize;
+    return MOCK_VIDEOS.slice(start, start + this.pageSize);
+  }
+}

--- a/apps/feed/src/bootstrap.ts
+++ b/apps/feed/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { FeedModule } from './app/feed.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(FeedModule)
+  .catch(err => console.error(err));

--- a/apps/feed/src/index.html
+++ b/apps/feed/src/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Feed</title>
+</head>
+<body>
+  <app-feed></app-feed>
+</body>
+</html>

--- a/apps/feed/src/main.ts
+++ b/apps/feed/src/main.ts
@@ -1,0 +1,1 @@
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/feed/tsconfig.json
+++ b/apps/feed/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/feed/webpack.config.js
+++ b/apps/feed/webpack.config.js
@@ -26,10 +26,10 @@ module.exports = {
   },
   plugins: [
     new ModuleFederationPlugin({
-      name: 'host',
+      name: 'feed',
       filename: 'remoteEntry.js',
-      remotes: {
-        feed: 'feed@http://localhost:3001/remoteEntry.js'
+      exposes: {
+        './FeedModule': './src/app/feed.module.ts'
       },
       shared: {
         '@angular/core': { singleton: true, strictVersion: true },
@@ -40,7 +40,7 @@ module.exports = {
     new HtmlWebpackPlugin({ template: './src/index.html' })
   ],
   devServer: {
-    port: 4200,
+    port: 3001,
     historyApiFallback: true
   }
 };

--- a/apps/host/src/app/app.component.ts
+++ b/apps/host/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
       <sv-button (clicked)="onShared()">Shared Button</sv-button>
       <nav>
         <a routerLink="/">Home</a> |
-        <a routerLink="/remote">Remote</a>
+        <a routerLink="/feed">Feed</a>
       </nav>
     </header>
     <router-outlet></router-outlet>

--- a/apps/host/src/app/app.module.ts
+++ b/apps/host/src/app/app.module.ts
@@ -7,8 +7,8 @@ import { UiKitModule } from '@short-video/ui-kit';
 const routes: Routes = [
   { path: '', component: AppComponent },
   {
-    path: 'remote',
-    loadChildren: () => import('remote/Module').then(m => m.RemoteModule)
+    path: 'feed',
+    loadChildren: () => import('feed/FeedModule').then(m => m.FeedModule)
   }
 ];
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Monorepo for micro frontends",
   "scripts": {
     "build": "pnpm -r build",
-    "start": "pnpm --filter host start"
+    "start": "pnpm --filter host start",
+    "start:feed": "pnpm --filter feed start"
   }
 }

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@short-video/event-bus",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "sideEffects": false
+}

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -1,0 +1,25 @@
+export type EventHandler<T = any> = (payload: T) => void;
+
+class EventBus {
+  private handlers = new Map<string, Set<EventHandler>>();
+
+  emit<T>(event: string, payload: T): void {
+    const set = this.handlers.get(event);
+    if (set) {
+      set.forEach(handler => handler(payload));
+    }
+  }
+
+  on<T>(event: string, handler: EventHandler<T>): () => void {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+    this.handlers.get(event)!.add(handler as EventHandler);
+    return () => this.handlers.get(event)!.delete(handler as EventHandler);
+  }
+}
+
+export const eventBus = new EventBus();
+export const EVENTS = {
+  VIDEO_VIEWED: 'VIDEO_VIEWED'
+};


### PR DESCRIPTION
## Summary
- scaffold Angular-based feed micro frontend and expose FeedModule via module federation
- add simple event bus package for cross-app events
- wire host to consume feed remote and add convenience start script

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -r build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b495a333ac8323abf4fda5e39301f5