### PR TITLE
feat(player): add HLS video player microfrontend

### DIFF
--- a/apps/player/package.json
+++ b/apps/player/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "player",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "hls.js": "^1.4.12",
+    "player.js": "^0.1.0"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "postcss": "^8.4.27",
+    "postcss-loader": "^7.3.2",
+    "tailwindcss": "^3.3.2",
+    "autoprefixer": "^10.4.14",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/player/postcss.config.js
+++ b/apps/player/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/player/src/app/player.module.ts
+++ b/apps/player/src/app/player.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VideoPlayerComponent } from './video-player.component';
+
+@NgModule({
+  declarations: [VideoPlayerComponent],
+  imports: [CommonModule],
+  exports: [VideoPlayerComponent],
+  bootstrap: [VideoPlayerComponent]
+})
+export class PlayerModule {}

--- a/apps/player/src/app/video-player.component.ts
+++ b/apps/player/src/app/video-player.component.ts
@@ -1,0 +1,87 @@
+import { AfterViewInit, Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core';
+import Hls from 'hls.js';
+import Player from 'player.js';
+
+@Component({
+  selector: 'app-video-player',
+  template: `
+    <ng-container *ngIf="isEmbed; else videoTpl">
+      <iframe
+        #frame
+        class="w-full h-60"
+        frameborder="0"
+        allow="autoplay; encrypted-media"
+        allowfullscreen
+      ></iframe>
+    </ng-container>
+    <ng-template #videoTpl>
+      <video #video class="w-full h-60" controls></video>
+    </ng-template>
+  `
+})
+export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
+  @Input() src = '';
+  @ViewChild('video') videoRef?: ElementRef<HTMLVideoElement>;
+  @ViewChild('frame') frameRef?: ElementRef<HTMLIFrameElement>;
+
+  private hls?: Hls;
+  private observer?: IntersectionObserver;
+  private player?: any;
+  isEmbed = false;
+
+  ngAfterViewInit() {
+    this.isEmbed = this.src.includes('embed');
+    const target = this.isEmbed
+      ? this.frameRef?.nativeElement
+      : this.videoRef?.nativeElement;
+
+    if (!target) {
+      return;
+    }
+
+    if (this.isEmbed) {
+      const frame = target as HTMLIFrameElement;
+      frame.src = this.src;
+      this.player = new Player(frame);
+    } else {
+      const video = target as HTMLVideoElement;
+      if (this.src.endsWith('.m3u8') && Hls.isSupported()) {
+        this.hls = new Hls();
+        this.hls.loadSource(this.src);
+        this.hls.attachMedia(video);
+      } else {
+        video.src = this.src;
+      }
+    }
+
+    this.observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (this.isEmbed) {
+            if (entry.isIntersecting) {
+              this.player?.play();
+            } else {
+              this.player?.pause();
+            }
+          } else {
+            const video = target as HTMLVideoElement;
+            if (entry.isIntersecting) {
+              video.play();
+            } else {
+              video.pause();
+            }
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    this.observer.observe(target);
+  }
+
+  ngOnDestroy() {
+    this.observer?.disconnect();
+    this.hls?.destroy();
+    this.player?.pause();
+  }
+}

--- a/apps/player/src/bootstrap.ts
+++ b/apps/player/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { PlayerModule } from './app/player.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(PlayerModule)
+  .catch(err => console.error(err));

--- a/apps/player/src/index.html
+++ b/apps/player/src/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Player</title>
+</head>
+<body>
+  <app-video-player src="https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"></app-video-player>
+</body>
+</html>

--- a/apps/player/src/main.ts
+++ b/apps/player/src/main.ts
@@ -1,0 +1,2 @@
+import './styles.css';
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/player/src/styles.css
+++ b/apps/player/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/player/src/styles.d.ts
+++ b/apps/player/src/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/apps/player/tailwind.config.js
+++ b/apps/player/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{html,ts}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/player/tsconfig.json
+++ b/apps/player/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/player/webpack.config.js
+++ b/apps/player/webpack.config.js
@@ -1,0 +1,45 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  output: {
+    publicPath: 'auto',
+    path: path.resolve(__dirname, 'dist')
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader', 'postcss-loader']
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'player',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './VideoPlayer': './src/app/video-player.component.ts'
+      },
+      shared: {
+        '@angular/core': { singleton: true, strictVersion: true },
+        '@angular/common': { singleton: true, strictVersion: true }
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ],
+  devServer: {
+    port: 3002,
+    historyApiFallback: true
+  }
+};

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -42,6 +42,7 @@
 - Micro frontends can be written in Angular, React, Vue, or other frameworks and federated at runtime.
 - Shared state via RxJS event bus or NgRx for Angular-based modules.
 - TailwindCSS-based UI kit shared via `packages/ui-kit`.
+- Player micro frontend leverages Tailwind CSS utility classes for layout and styling.
 - SSR or pre-render using Angular Universal (or each microFE's native solution).
 - Video playback using `hls.js` or `video.js`.
 


### PR DESCRIPTION
## Summary
- add player.js dependency to handle embedded player control
- use Player.js to play/pause embeds based on viewport visibility while keeping HLS support
- integrate Tailwind CSS in player micro frontend and document usage

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm --filter player build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b49729b0f0832383137e20278e799e