### PR TITLE
feat: add auth and profile apps with shared utilities

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "auth",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "@supabase/supabase-js": "^2.39.7",
+    "@short-video/shared-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/auth/src/app/auth.component.ts
+++ b/apps/auth/src/app/auth.component.ts
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { createClient } from '@supabase/supabase-js';
+import { setToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
+
+const supabaseUrl = 'SUPABASE_URL';
+const supabaseKey = 'SUPABASE_KEY';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <h2>Login</h2>
+    <form [formGroup]="loginForm" (ngSubmit)="login()">
+      <input type="email" formControlName="email" placeholder="Email" required />
+      <input type="password" formControlName="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+    </form>
+
+    <h2>Register</h2>
+    <form [formGroup]="registerForm" (ngSubmit)="register()">
+      <input type="email" formControlName="email" placeholder="Email" required />
+      <input type="password" formControlName="password" placeholder="Password" required />
+      <button type="submit">Register</button>
+    </form>
+    <p>{{message}}</p>
+  `
+})
+export class AuthComponent {
+  loginForm: FormGroup;
+  registerForm: FormGroup;
+  message = '';
+
+  constructor(private fb: FormBuilder) {
+    this.loginForm = this.fb.group({
+      email: [''],
+      password: [''],
+    });
+    this.registerForm = this.fb.group({
+      email: [''],
+      password: [''],
+    });
+  }
+
+  async login() {
+    const { email, password } = this.loginForm.value;
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (data?.session) {
+      setToken(data.session.access_token);
+      authEventBus.emit(AUTH_EVENTS.AUTH_CHANGED, data.session.user);
+      this.message = 'Logged in';
+    } else if (error) {
+      this.message = error.message;
+    }
+  }
+
+  async register() {
+    const { email, password } = this.registerForm.value;
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (data?.session) {
+      setToken(data.session.access_token);
+      authEventBus.emit(AUTH_EVENTS.AUTH_CHANGED, data.session.user);
+      this.message = 'Registered';
+    } else if (error) {
+      this.message = error.message;
+    }
+  }
+}

--- a/apps/auth/src/app/auth.module.ts
+++ b/apps/auth/src/app/auth.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { ReactiveFormsModule } from '@angular/forms';
+import { AuthComponent } from './auth.component';
+
+@NgModule({
+  declarations: [AuthComponent],
+  imports: [BrowserModule, ReactiveFormsModule],
+  exports: [AuthComponent]
+})
+export class AuthModule {}

--- a/apps/auth/src/bootstrap.ts
+++ b/apps/auth/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AuthModule } from './app/auth.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AuthModule)
+  .catch(err => console.error(err));

--- a/apps/auth/src/index.html
+++ b/apps/auth/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Auth</title>
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/apps/auth/src/main.ts
+++ b/apps/auth/src/main.ts
@@ -1,0 +1,1 @@
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/auth/webpack.config.js
+++ b/apps/auth/webpack.config.js
@@ -1,0 +1,46 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  output: {
+    publicPath: 'auto',
+    path: path.resolve(__dirname, 'dist')
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'auth',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './AuthModule': './src/app/auth.module.ts'
+      },
+      shared: {
+        '@angular/core': { singleton: true, strictVersion: true },
+        '@angular/common': { singleton: true, strictVersion: true },
+        '@angular/router': { singleton: true, strictVersion: true }
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ],
+  devServer: {
+    port: 3002,
+    historyApiFallback: true
+  }
+};

--- a/apps/profile/package.json
+++ b/apps/profile/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "profile",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "@supabase/supabase-js": "^2.39.7",
+    "@short-video/shared-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/profile/src/app/profile.component.ts
+++ b/apps/profile/src/app/profile.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnDestroy } from '@angular/core';
+import { createClient } from '@supabase/supabase-js';
+import { getToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
+
+const supabaseUrl = 'SUPABASE_URL';
+const supabaseKey = 'SUPABASE_KEY';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <div *ngIf="user; else loggedOut">
+      <h2>{{user.email}}</h2>
+      <h3>Your Videos</h3>
+      <ul>
+        <li *ngFor="let v of videos">{{v.title}}</li>
+      </ul>
+    </div>
+    <ng-template #loggedOut>
+      <p>Please log in.</p>
+    </ng-template>
+  `
+})
+export class ProfileComponent implements OnDestroy {
+  user: any = null;
+  videos: any[] = [];
+  private unsub?: () => void;
+
+  constructor() {
+    this.unsub = authEventBus.on(AUTH_EVENTS.AUTH_CHANGED, user => {
+      this.user = user;
+      this.loadVideos();
+    });
+    this.init();
+  }
+
+  ngOnDestroy() {
+    this.unsub && this.unsub();
+  }
+
+  private async init() {
+    const token = getToken();
+    if (!token) return;
+    const { data } = await supabase.auth.getUser(token);
+    this.user = data.user;
+    this.loadVideos();
+  }
+
+  private async loadVideos() {
+    if (!this.user) return;
+    const { data } = await supabase.from('videos').select('*').eq('user_id', this.user.id);
+    this.videos = data || [];
+  }
+}

--- a/apps/profile/src/app/profile.module.ts
+++ b/apps/profile/src/app/profile.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { ProfileComponent } from './profile.component';
+
+@NgModule({
+  declarations: [ProfileComponent],
+  imports: [BrowserModule],
+  exports: [ProfileComponent]
+})
+export class ProfileModule {}

--- a/apps/profile/src/bootstrap.ts
+++ b/apps/profile/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { ProfileModule } from './app/profile.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(ProfileModule)
+  .catch(err => console.error(err));

--- a/apps/profile/src/index.html
+++ b/apps/profile/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Profile</title>
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/apps/profile/src/main.ts
+++ b/apps/profile/src/main.ts
@@ -1,0 +1,1 @@
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/profile/tsconfig.json
+++ b/apps/profile/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/profile/webpack.config.js
+++ b/apps/profile/webpack.config.js
@@ -1,0 +1,46 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  output: {
+    publicPath: 'auto',
+    path: path.resolve(__dirname, 'dist')
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'profile',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './ProfileModule': './src/app/profile.module.ts'
+      },
+      shared: {
+        '@angular/core': { singleton: true, strictVersion: true },
+        '@angular/common': { singleton: true, strictVersion: true },
+        '@angular/router': { singleton: true, strictVersion: true }
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ],
+  devServer: {
+    port: 3003,
+    historyApiFallback: true
+  }
+};

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@short-video/shared-utils",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "dependencies": {
+    "@short-video/event-bus": "workspace:*"
+  }
+}

--- a/packages/shared-utils/src/auth-events.ts
+++ b/packages/shared-utils/src/auth-events.ts
@@ -1,0 +1,7 @@
+import { eventBus } from '@short-video/event-bus';
+
+export const AUTH_EVENTS = {
+  AUTH_CHANGED: 'AUTH_CHANGED'
+};
+
+export const authEventBus = eventBus;

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -1,0 +1,2 @@
+export * from './token';
+export * from './auth-events';

--- a/packages/shared-utils/src/token.ts
+++ b/packages/shared-utils/src/token.ts
@@ -1,0 +1,13 @@
+const TOKEN_KEY = 'sv_token';
+
+export function setToken(token: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function clearToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}


### PR DESCRIPTION
## Summary
- add shared-utils package for token handling and auth events
- build auth micro frontend with Supabase login and registration
- build profile micro frontend to show user info and uploaded videos
- refactor auth forms to reactive FormGroups instead of ngModel

## Testing
- `pnpm -r build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bd6e354832387648fb95924c79d