### PR TITLE
feat: add shared utilities and ui kit integration

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,7 +16,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@supabase/supabase-js": "^2.39.7",
-    "@short-video/shared-utils": "workspace:*"
+    "@short-video/shared-utils": "workspace:*",
+    "@short-video/ui-kit": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/auth/src/app/auth.component.ts
+++ b/apps/auth/src/app/auth.component.ts
@@ -14,14 +14,14 @@ const supabase = createClient(supabaseUrl, supabaseKey);
     <form [formGroup]="loginForm" (ngSubmit)="login()">
       <input type="email" formControlName="email" placeholder="Email" required />
       <input type="password" formControlName="password" placeholder="Password" required />
-      <button type="submit">Login</button>
+      <sv-button>Login</sv-button>
     </form>
 
     <h2>Register</h2>
     <form [formGroup]="registerForm" (ngSubmit)="register()">
       <input type="email" formControlName="email" placeholder="Email" required />
       <input type="password" formControlName="password" placeholder="Password" required />
-      <button type="submit">Register</button>
+      <sv-button>Register</sv-button>
     </form>
     <p>{{message}}</p>
   `

--- a/apps/auth/src/app/auth.module.ts
+++ b/apps/auth/src/app/auth.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AuthComponent } from './auth.component';
+import { UiKitModule } from '@short-video/ui-kit';
 
 @NgModule({
   declarations: [AuthComponent],
-  imports: [BrowserModule, ReactiveFormsModule],
+  imports: [BrowserModule, ReactiveFormsModule, UiKitModule],
   exports: [AuthComponent]
 })
 export class AuthModule {}

--- a/apps/feed/package.json
+++ b/apps/feed/package.json
@@ -15,7 +15,8 @@
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
-    "@short-video/event-bus": "workspace:*"
+    "@short-video/shared-utils": "workspace:*",
+    "@short-video/ui-kit": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/feed/src/app/feed.component.ts
+++ b/apps/feed/src/app/feed.component.ts
@@ -1,6 +1,6 @@
 import { Component, AfterViewInit, ViewChildren, ElementRef, QueryList, HostListener } from '@angular/core';
 import { VideoService, Video } from './video.service';
-import { eventBus, EVENTS } from '@short-video/event-bus';
+import { trackEvent, ANALYTICS_EVENTS } from '@short-video/shared-utils';
 
 @Component({
   selector: 'app-feed',
@@ -10,6 +10,7 @@ import { eventBus, EVENTS } from '@short-video/event-bus';
       <video width="320" height="240" controls [src]="video.src"></video>
     </div>
     <div *ngIf="loading" class="loading">Loading...</div>
+    <sv-button (clicked)="loadMore()">Load More</sv-button>
   `,
   styles: ['.video{margin-bottom:24px;}']
 })
@@ -35,7 +36,7 @@ export class FeedComponent implements AfterViewInit {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
           const id = Number((entry.target as HTMLElement).dataset['id']);
-          eventBus.emit(EVENTS.VIDEO_VIEWED, { id });
+          trackEvent(ANALYTICS_EVENTS.VIDEO_VIEWED, { id });
           observer.unobserve(entry.target);
         }
       });
@@ -50,7 +51,7 @@ export class FeedComponent implements AfterViewInit {
     }
   }
 
-  private loadMore() {
+  loadMore() {
     this.loading = true;
     this.videoService.getVideos(this.page++).then(newVideos => {
       this.videos = this.videos.concat(newVideos);

--- a/apps/feed/src/app/feed.module.ts
+++ b/apps/feed/src/app/feed.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FeedComponent } from './feed.component';
+import { UiKitModule } from '@short-video/ui-kit';
 
 @NgModule({
   declarations: [FeedComponent],
-  imports: [BrowserModule],
+  imports: [BrowserModule, UiKitModule],
   exports: [FeedComponent]
 })
 export class FeedModule {}

--- a/apps/feed/src/app/video.service.ts
+++ b/apps/feed/src/app/video.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { apiFetch } from '@short-video/shared-utils';
 
 export interface Video {
   id: number;
@@ -17,7 +18,11 @@ export class VideoService {
   private pageSize = 10;
 
   async getVideos(page: number): Promise<Video[]> {
-    const start = page * this.pageSize;
-    return MOCK_VIDEOS.slice(start, start + this.pageSize);
+    try {
+      return await apiFetch<Video[]>(`/videos?page=${page}`);
+    } catch {
+      const start = page * this.pageSize;
+      return MOCK_VIDEOS.slice(start, start + this.pageSize);
+    }
   }
 }

--- a/apps/host/package.json
+++ b/apps/host/package.json
@@ -15,7 +15,8 @@
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/shared-utils": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/host/src/app/app.component.ts
+++ b/apps/host/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
+import { onEvent, ANALYTICS_EVENTS } from '@short-video/shared-utils';
 
 @Component({
   selector: 'app-root',
@@ -14,8 +15,20 @@ import { Component } from '@angular/core';
     <router-outlet></router-outlet>
   `
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
+  private unsub: () => void;
+
+  constructor() {
+    this.unsub = onEvent(ANALYTICS_EVENTS.VIDEO_VIEWED, data => {
+      console.log('Analytics event', data);
+    });
+  }
+
   onShared() {
     alert('Shared Button');
+  }
+
+  ngOnDestroy() {
+    this.unsub && this.unsub();
   }
 }

--- a/apps/player/package.json
+++ b/apps/player/package.json
@@ -16,7 +16,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "hls.js": "^1.4.12",
-    "player.js": "^0.1.0"
+    "player.js": "^0.1.0",
+    "@short-video/ui-kit": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/player/src/app/player.module.ts
+++ b/apps/player/src/app/player.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { VideoPlayerComponent } from './video-player.component';
+import { UiKitModule } from '@short-video/ui-kit';
 
 @NgModule({
   declarations: [VideoPlayerComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, UiKitModule],
   exports: [VideoPlayerComponent],
   bootstrap: [VideoPlayerComponent]
 })

--- a/apps/player/src/app/video-player.component.ts
+++ b/apps/player/src/app/video-player.component.ts
@@ -5,6 +5,7 @@ import Player from 'player.js';
 @Component({
   selector: 'app-video-player',
   template: `
+    <sv-button (clicked)="toggleMute()">Toggle Mute</sv-button>
     <ng-container *ngIf="isEmbed; else videoTpl">
       <iframe
         #frame
@@ -83,5 +84,12 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     this.observer?.disconnect();
     this.hls?.destroy();
     this.player?.pause();
+  }
+
+  toggleMute() {
+    const video = this.videoRef?.nativeElement;
+    if (video) {
+      video.muted = !video.muted;
+    }
   }
 }

--- a/apps/profile/package.json
+++ b/apps/profile/package.json
@@ -16,7 +16,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@supabase/supabase-js": "^2.39.7",
-    "@short-video/shared-utils": "workspace:*"
+    "@short-video/shared-utils": "workspace:*",
+    "@short-video/ui-kit": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/profile/src/app/profile.component.ts
+++ b/apps/profile/src/app/profile.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { createClient } from '@supabase/supabase-js';
-import { getToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
+import { getToken, clearToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
 
 const supabaseUrl = 'SUPABASE_URL';
 const supabaseKey = 'SUPABASE_KEY';
@@ -15,6 +15,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
       <ul>
         <li *ngFor="let v of videos">{{v.title}}</li>
       </ul>
+      <sv-button (clicked)="logout()">Logout</sv-button>
     </div>
     <ng-template #loggedOut>
       <p>Please log in.</p>
@@ -50,5 +51,13 @@ export class ProfileComponent implements OnDestroy {
     if (!this.user) return;
     const { data } = await supabase.from('videos').select('*').eq('user_id', this.user.id);
     this.videos = data || [];
+  }
+
+  async logout() {
+    await supabase.auth.signOut();
+    clearToken();
+    authEventBus.emit(AUTH_EVENTS.AUTH_CHANGED, null);
+    this.user = null;
+    this.videos = [];
   }
 }

--- a/apps/profile/src/app/profile.module.ts
+++ b/apps/profile/src/app/profile.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ProfileComponent } from './profile.component';
+import { UiKitModule } from '@short-video/ui-kit';
 
 @NgModule({
   declarations: [ProfileComponent],
-  imports: [BrowserModule],
+  imports: [BrowserModule, UiKitModule],
   exports: [ProfileComponent]
 })
 export class ProfileModule {}

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -4,6 +4,6 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "dependencies": {
-    "@short-video/event-bus": "workspace:*"
+    "rxjs": "^7.8.1"
   }
 }

--- a/packages/shared-utils/src/analytics.ts
+++ b/packages/shared-utils/src/analytics.ts
@@ -1,0 +1,14 @@
+import { eventBus } from './event-bus';
+
+export const ANALYTICS_EVENTS = {
+  VIDEO_VIEWED: 'VIDEO_VIEWED'
+};
+
+export function trackEvent<T>(event: string, payload: T): void {
+  eventBus.emit(event, payload);
+}
+
+export function onEvent<T>(event: string, handler: (payload: T) => void): () => void {
+  const subscription = eventBus.on<T>(event).subscribe(handler);
+  return () => subscription.unsubscribe();
+}

--- a/packages/shared-utils/src/api.ts
+++ b/packages/shared-utils/src/api.ts
@@ -1,0 +1,22 @@
+import { getToken } from './token';
+
+const API_BASE = '/api';
+
+export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = getToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string> | undefined),
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return response.json() as Promise<T>;
+}

--- a/packages/shared-utils/src/auth-events.ts
+++ b/packages/shared-utils/src/auth-events.ts
@@ -1,4 +1,4 @@
-import { eventBus } from '@short-video/event-bus';
+import { eventBus } from './event-bus';
 
 export const AUTH_EVENTS = {
   AUTH_CHANGED: 'AUTH_CHANGED'

--- a/packages/shared-utils/src/event-bus.ts
+++ b/packages/shared-utils/src/event-bus.ts
@@ -1,0 +1,24 @@
+import { Subject, Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+
+interface BusEvent<T> {
+  name: string;
+  payload: T;
+}
+
+class EventBus {
+  private subject = new Subject<BusEvent<any>>();
+
+  emit<T>(event: string, payload: T): void {
+    this.subject.next({ name: event, payload });
+  }
+
+  on<T>(event: string): Observable<T> {
+    return this.subject.asObservable().pipe(
+      filter(e => e.name === event),
+      map(e => e.payload as T)
+    );
+  }
+}
+
+export const eventBus = new EventBus();

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -1,2 +1,5 @@
 export * from './token';
 export * from './auth-events';
+export * from './event-bus';
+export * from './api';
+export * from './analytics';


### PR DESCRIPTION
## Summary
- build RxJS-powered event bus with API and analytics helpers in shared-utils
- wire micro frontends to use ui-kit components and shared analytics bus
- switch feed service to token-aware apiFetch helper

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b52183bdf4832385445be97a512404