### PR TITLE
Integrate Supabase across micro frontends

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -15,7 +15,6 @@
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
-    "@supabase/supabase-js": "^2.39.7",
     "@short-video/shared-utils": "workspace:*",
     "@short-video/ui-kit": "workspace:*"
   },

--- a/apps/auth/src/app/auth.component.ts
+++ b/apps/auth/src/app/auth.component.ts
@@ -1,11 +1,6 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { createClient } from '@supabase/supabase-js';
-import { setToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
-
-const supabaseUrl = 'SUPABASE_URL';
-const supabaseKey = 'SUPABASE_KEY';
-const supabase = createClient(supabaseUrl, supabaseKey);
+import { setToken, authEventBus, AUTH_EVENTS, supabase } from '@short-video/shared-utils';
 
 @Component({
   selector: 'app-root',

--- a/apps/feed/src/app/feed.component.ts
+++ b/apps/feed/src/app/feed.component.ts
@@ -5,13 +5,15 @@ import { trackEvent, ANALYTICS_EVENTS } from '@short-video/shared-utils';
 @Component({
   selector: 'app-feed',
   template: `
-    <div class="video" *ngFor="let video of videos" #videoRef [attr.data-id]="video.id">
-      <h3>{{video.title}}</h3>
-      <video width="320" height="240" controls [src]="video.src"></video>
-    </div>
-    <div *ngIf="loading" class="loading">Loading...</div>
-    <sv-button (clicked)="loadMore()">Load More</sv-button>
-  `,
+      <div class="video" *ngFor="let video of videos" #videoRef [attr.data-id]="video.id">
+        <h3>{{video.title}}</h3>
+        <video width="320" height="240" controls [src]="video.src"></video>
+        <div>Likes: {{video.likes || 0}}</div>
+        <sv-button (clicked)="like(video)">Like</sv-button>
+      </div>
+      <div *ngIf="loading" class="loading">Loading...</div>
+      <sv-button (clicked)="loadMore()">Load More</sv-button>
+    `,
   styles: ['.video{margin-bottom:24px;}']
 })
 export class FeedComponent implements AfterViewInit {
@@ -55,7 +57,14 @@ export class FeedComponent implements AfterViewInit {
     this.loading = true;
     this.videoService.getVideos(this.page++).then(newVideos => {
       this.videos = this.videos.concat(newVideos);
+      newVideos.forEach(v =>
+        this.videoService.onLikes(v.id, count => (v.likes = count))
+      );
       this.loading = false;
     });
+  }
+
+  like(video: Video) {
+    this.videoService.likeVideo(video.id);
   }
 }

--- a/apps/feed/src/app/video.service.ts
+++ b/apps/feed/src/app/video.service.ts
@@ -1,28 +1,72 @@
 import { Injectable } from '@angular/core';
-import { apiFetch } from '@short-video/shared-utils';
+import { supabase } from '@short-video/shared-utils';
 
 export interface Video {
   id: number;
   title: string;
   src: string;
+  likes?: number;
 }
 
-const MOCK_VIDEOS: Video[] = Array.from({ length: 100 }).map((_, i) => ({
-  id: i + 1,
-  title: `Video ${i + 1}`,
-  src: `https://placehold.co/320x240?text=Video+${i + 1}`
-}));
+export interface Comment {
+  id: number;
+  video_id: number;
+  content: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class VideoService {
   private pageSize = 10;
 
   async getVideos(page: number): Promise<Video[]> {
-    try {
-      return await apiFetch<Video[]>(`/videos?page=${page}`);
-    } catch {
-      const start = page * this.pageSize;
-      return MOCK_VIDEOS.slice(start, start + this.pageSize);
-    }
+    const start = page * this.pageSize;
+    const end = start + this.pageSize - 1;
+    const { data } = await supabase
+      .from('videos')
+      .select('id,title,file_path')
+      .range(start, end);
+    if (!data) return [];
+    return data.map(v => ({
+      id: v.id,
+      title: v.title,
+      src: supabase.storage.from('videos').getPublicUrl(v.file_path).data.publicUrl,
+      likes: 0,
+    }));
+  }
+
+  async likeVideo(videoId: number): Promise<void> {
+    await supabase.from('likes').insert({ video_id: videoId });
+  }
+
+  onLikes(videoId: number, cb: (count: number) => void) {
+    return supabase
+      .channel('public:likes')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'likes', filter: `video_id=eq.${videoId}` },
+        async () => {
+          const { count } = await supabase
+            .from('likes')
+            .select('*', { count: 'exact', head: true })
+            .eq('video_id', videoId);
+          cb(count || 0);
+        }
+      )
+      .subscribe();
+  }
+
+  async addComment(videoId: number, content: string): Promise<void> {
+    await supabase.from('comments').insert({ video_id: videoId, content });
+  }
+
+  onComments(videoId: number, cb: (comment: Comment) => void) {
+    return supabase
+      .channel('public:comments')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'comments', filter: `video_id=eq.${videoId}` },
+        payload => cb(payload.new as Comment)
+      )
+      .subscribe();
   }
 }

--- a/apps/profile/package.json
+++ b/apps/profile/package.json
@@ -15,7 +15,6 @@
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
-    "@supabase/supabase-js": "^2.39.7",
     "@short-video/shared-utils": "workspace:*",
     "@short-video/ui-kit": "workspace:*"
   },

--- a/apps/profile/src/app/profile.component.ts
+++ b/apps/profile/src/app/profile.component.ts
@@ -1,10 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { createClient } from '@supabase/supabase-js';
-import { getToken, clearToken, authEventBus, AUTH_EVENTS } from '@short-video/shared-utils';
-
-const supabaseUrl = 'SUPABASE_URL';
-const supabaseKey = 'SUPABASE_KEY';
-const supabase = createClient(supabaseUrl, supabaseKey);
+import { getToken, clearToken, authEventBus, AUTH_EVENTS, supabase } from '@short-video/shared-utils';
 
 @Component({
   selector: 'app-root',

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,68 @@
+# Supabase Setup
+
+The project uses [Supabase](https://supabase.com) for authentication, database access, storage and real-time updates.  Below are the SQL commands and steps to configure a project.
+
+## Database schema
+
+```sql
+-- Table for additional profile information.
+create table profiles (
+  id uuid references auth.users on delete cascade primary key,
+  username text,
+  avatar_url text,
+  created_at timestamp default now()
+);
+
+-- Videos uploaded by users.  `file_path` points to a file in the `videos` storage bucket.
+create table videos (
+  id bigint generated always as identity primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  file_path text not null,
+  created_at timestamp default now()
+);
+
+-- Comments on a video.
+create table comments (
+  id bigint generated always as identity primary key,
+  video_id bigint references videos(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  content text not null,
+  created_at timestamp default now()
+);
+
+-- Likes for a video.  Duplicate likes are prevented with a unique constraint.
+create table likes (
+  id bigint generated always as identity primary key,
+  video_id bigint references videos(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  created_at timestamp default now(),
+  unique(video_id, user_id)
+);
+```
+
+Enable the tables for real‑time features:
+
+```sql
+alter publication supabase_realtime add table likes;
+alter publication supabase_realtime add table comments;
+```
+
+## Storage bucket
+
+Create a bucket to store uploaded video files and make it public so videos can be served directly.
+
+```bash
+supabase storage buckets create videos --public
+```
+
+## Environment variables
+
+Expose your project keys to the applications via environment variables:
+
+```bash
+export SUPABASE_URL=your-project-url
+export SUPABASE_ANON_KEY=your-anon-key
+```
+
+These values are read by the shared `supabase` client in the front‑end apps.

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "dependencies": {
+    "@supabase/supabase-js": "^2.39.7",
     "rxjs": "^7.8.1"
   }
 }

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './auth-events';
 export * from './event-bus';
 export * from './api';
 export * from './analytics';
+export * from './supabase';

--- a/packages/shared-utils/src/supabase.ts
+++ b/packages/shared-utils/src/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+// These placeholders should be replaced with actual values at build time or
+// provided through environment variables in the hosting application.
+const SUPABASE_URL = (process.env.SUPABASE_URL as string) || 'SUPABASE_URL';
+const SUPABASE_ANON_KEY = (process.env.SUPABASE_ANON_KEY as string) || 'SUPABASE_ANON_KEY';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- add shared Supabase client and dependency
- migrate auth, profile and feed apps to use Supabase for auth, video data and realtime likes/comments
- document database schema, storage bucket and realtime configuration for Supabase

## Testing
- ⚠️ `pnpm install` *(failed: Proxy response (403) when fetching packages)*
- ⚠️ `pnpm -r build` *(failed: Proxy response (403) when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b523901a208323b48fedd3efc1e5b9