### PR TITLE
feat: add comments app and realtime counts

### DIFF
--- a/apps/comments/package.json
+++ b/apps/comments/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "comments",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "start": "webpack serve --config webpack.config.js --mode development --open",
+    "build": "webpack --config webpack.config.js --mode production"
+  },
+  "dependencies": {
+    "@angular/animations": "^16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/compiler": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/forms": "^16.0.0",
+    "@angular/platform-browser": "^16.0.0",
+    "@angular/platform-browser-dynamic": "^16.0.0",
+    "@angular/router": "^16.0.0",
+    "@short-video/shared-utils": "workspace:*",
+    "@short-video/ui-kit": "workspace:*"
+  },
+  "devDependencies": {
+    "@angular-architects/module-federation": "^16.0.0",
+    "typescript": "^5.0.0",
+    "ts-loader": "^9.5.0",
+    "html-webpack-plugin": "^5.5.0",
+    "css-loader": "^6.8.1",
+    "style-loader": "^3.3.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/apps/comments/src/app/comments.component.ts
+++ b/apps/comments/src/app/comments.component.ts
@@ -1,0 +1,60 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { supabase } from '@short-video/shared-utils';
+
+interface Comment {
+  id: number;
+  video_id: number;
+  content: string;
+}
+
+@Component({
+  selector: 'app-comments',
+  template: `
+    <div *ngFor="let c of comments">{{c.content}}</div>
+    <form [formGroup]="form" (ngSubmit)="addComment()">
+      <input type="text" formControlName="content" placeholder="Add a comment" />
+      <sv-button>Submit</sv-button>
+    </form>
+  `
+})
+export class CommentsComponent implements OnInit, OnDestroy {
+  @Input() videoId!: number;
+  comments: Comment[] = [];
+  form: FormGroup;
+  private channel: any;
+
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({ content: [''] });
+  }
+
+  async ngOnInit() {
+    if (!this.videoId) return;
+    const { data } = await supabase
+      .from<Comment>('comments')
+      .select('*')
+      .eq('video_id', this.videoId);
+    this.comments = data || [];
+    this.channel = supabase
+      .channel('public:comments')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'comments', filter: `video_id=eq.${this.videoId}` },
+        payload => {
+          this.comments.push(payload.new as Comment);
+        }
+      )
+      .subscribe();
+  }
+
+  async addComment() {
+    const content = this.form.value.content;
+    if (!content) return;
+    await supabase.from('comments').insert({ video_id: this.videoId, content });
+    this.form.reset();
+  }
+
+  ngOnDestroy() {
+    this.channel?.unsubscribe();
+  }
+}

--- a/apps/comments/src/app/comments.module.ts
+++ b/apps/comments/src/app/comments.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CommentsComponent } from './comments.component';
+import { UiKitModule } from '@short-video/ui-kit';
+
+@NgModule({
+  declarations: [CommentsComponent],
+  imports: [CommonModule, ReactiveFormsModule, UiKitModule],
+  exports: [CommentsComponent],
+  bootstrap: [CommentsComponent]
+})
+export class CommentsModule {}

--- a/apps/comments/src/bootstrap.ts
+++ b/apps/comments/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { CommentsModule } from './app/comments.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(CommentsModule)
+  .catch(err => console.error(err));

--- a/apps/comments/src/index.html
+++ b/apps/comments/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Comments</title>
+</head>
+<body>
+  <app-comments></app-comments>
+</body>
+</html>

--- a/apps/comments/src/main.ts
+++ b/apps/comments/src/main.ts
@@ -1,0 +1,1 @@
+import('./bootstrap').catch(err => console.error(err));

--- a/apps/comments/tsconfig.json
+++ b/apps/comments/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*"]
+}

--- a/apps/comments/webpack.config.js
+++ b/apps/comments/webpack.config.js
@@ -1,0 +1,46 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  output: {
+    publicPath: 'auto',
+    path: path.resolve(__dirname, 'dist')
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'comments',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './CommentsModule': './src/app/comments.module.ts'
+      },
+      shared: {
+        '@angular/core': { singleton: true, strictVersion: true },
+        '@angular/common': { singleton: true, strictVersion: true },
+        '@angular/router': { singleton: true, strictVersion: true }
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ],
+  devServer: {
+    port: 3004,
+    historyApiFallback: true
+  }
+};

--- a/apps/feed/src/app/feed.component.ts
+++ b/apps/feed/src/app/feed.component.ts
@@ -9,6 +9,7 @@ import { trackEvent, ANALYTICS_EVENTS } from '@short-video/shared-utils';
         <h3>{{video.title}}</h3>
         <video width="320" height="240" controls [src]="video.src"></video>
         <div>Likes: {{video.likes || 0}}</div>
+        <div>Comments: {{video.comments || 0}}</div>
         <sv-button (clicked)="like(video)">Like</sv-button>
       </div>
       <div *ngIf="loading" class="loading">Loading...</div>
@@ -57,9 +58,10 @@ export class FeedComponent implements AfterViewInit {
     this.loading = true;
     this.videoService.getVideos(this.page++).then(newVideos => {
       this.videos = this.videos.concat(newVideos);
-      newVideos.forEach(v =>
-        this.videoService.onLikes(v.id, count => (v.likes = count))
-      );
+      newVideos.forEach(v => {
+        this.videoService.onLikes(v.id, count => (v.likes = count));
+        this.videoService.onCommentsCount(v.id, count => (v.comments = count));
+      });
       this.loading = false;
     });
   }

--- a/apps/feed/src/app/video.service.ts
+++ b/apps/feed/src/app/video.service.ts
@@ -6,6 +6,7 @@ export interface Video {
   title: string;
   src: string;
   likes?: number;
+  comments?: number;
 }
 
 export interface Comment {
@@ -47,6 +48,23 @@ export class VideoService {
         async () => {
           const { count } = await supabase
             .from('likes')
+            .select('*', { count: 'exact', head: true })
+            .eq('video_id', videoId);
+          cb(count || 0);
+        }
+      )
+      .subscribe();
+  }
+
+  onCommentsCount(videoId: number, cb: (count: number) => void) {
+    return supabase
+      .channel('public:comments')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'comments', filter: `video_id=eq.${videoId}` },
+        async () => {
+          const { count } = await supabase
+            .from('comments')
             .select('*', { count: 'exact', head: true })
             .eq('video_id', videoId);
           cb(count || 0);


### PR DESCRIPTION
## Summary
- add standalone comments microfrontend with realtime updates and submission form
- stream like and comment counts through Supabase realtime
- surface live like/comment stats in feed and player components

## Testing
- `pnpm --filter feed build` *(fails: webpack: not found)*
- `pnpm --filter feed install` *(fails: GET https://registry.npmjs.org/ts-loader: Forbidden - 403)*
- `pnpm --filter player build` *(fails: webpack: not found)*
- `pnpm --filter player install` *(fails: GET https://registry.npmjs.org/@angular-architects%2Fmodule-federation: Forbidden - 403)*
- `pnpm --filter comments build` *(fails: webpack: not found)*
- `pnpm --filter comments install` *(fails: GET https://registry.npmjs.org/html-webpack-plugin: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b52491d45c83238f7ed40c678e96cc