### PR TITLE
chore: add ci and deployment setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - apps/auth
+          - apps/comments
+          - apps/feed
+          - apps/host
+          - apps/player
+          - apps/profile
+          - packages/event-bus
+          - packages/shared-utils
+          - packages/ui-kit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm --filter "${{ matrix.project }}" run build
+      - run: pnpm --filter "${{ matrix.project }}" run test --if-present

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter auth build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/auth/dist/ /usr/share/nginx/html

--- a/apps/comments/Dockerfile
+++ b/apps/comments/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter comments build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/comments/dist/ /usr/share/nginx/html

--- a/apps/feed/Dockerfile
+++ b/apps/feed/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter feed build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/feed/dist/ /usr/share/nginx/html

--- a/apps/host/Dockerfile
+++ b/apps/host/Dockerfile
@@ -1,0 +1,18 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG FEED_REMOTE_URL
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV FEED_REMOTE_URL=$FEED_REMOTE_URL
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter host build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/host/dist/ /usr/share/nginx/html

--- a/apps/host/webpack.config.js
+++ b/apps/host/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
       name: 'host',
       filename: 'remoteEntry.js',
       remotes: {
-        feed: 'feed@http://localhost:3001/remoteEntry.js'
+        feed: `feed@${process.env.FEED_REMOTE_URL || 'http://localhost:3001/remoteEntry.js'}`
       },
       shared: {
         '@angular/core': { singleton: true, strictVersion: true },

--- a/apps/player/Dockerfile
+++ b/apps/player/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter player build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/player/dist/ /usr/share/nginx/html

--- a/apps/profile/Dockerfile
+++ b/apps/profile/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+RUN npm install -g pnpm && pnpm install
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV SUPABASE_URL=$SUPABASE_URL
+ENV SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+RUN pnpm --filter profile build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/apps/profile/dist/ /usr/share/nginx/html

--- a/k8s/feed.yaml
+++ b/k8s/feed.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: feed
+  template:
+    metadata:
+      labels:
+        app: feed
+    spec:
+      containers:
+        - name: feed
+          image: ghcr.io/your-org/feed:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: SUPABASE_URL
+              value: https://your-supabase-url
+            - name: SUPABASE_ANON_KEY
+              value: your-supabase-anon-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: feed
+spec:
+  selector:
+    app: feed
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/k8s/host.yaml
+++ b/k8s/host.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: host
+  template:
+    metadata:
+      labels:
+        app: host
+    spec:
+      containers:
+        - name: host
+          image: ghcr.io/your-org/host:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: FEED_REMOTE_URL
+              value: http://feed/remoteEntry.js
+            - name: SUPABASE_URL
+              value: https://your-supabase-url
+            - name: SUPABASE_ANON_KEY
+              value: your-supabase-anon-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: host
+spec:
+  selector:
+    app: host
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- build each app and package via GitHub Actions
- add Dockerfiles and k8s manifests for micro frontends
- allow host to reference remote feed via env var

## Testing
- `pnpm --filter host build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b529ee7ed883239c89be75097ea417