### PR TITLE
feat: add monitoring and tests

### DIFF
--- a/apps/auth/jest.config.js
+++ b/apps/auth/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -16,7 +17,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@short-video/shared-utils": "workspace:*",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/monitoring": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/auth/src/app/auth.module.test.ts
+++ b/apps/auth/src/app/auth.module.test.ts
@@ -1,0 +1,7 @@
+import { AuthModule } from './auth.module';
+
+describe('AuthModule', () => {
+  it('should be defined', () => {
+    expect(AuthModule).toBeDefined();
+  });
+});

--- a/apps/auth/src/main.ts
+++ b/apps/auth/src/main.ts
@@ -1,1 +1,4 @@
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/apps/comments/jest.config.js
+++ b/apps/comments/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/comments/package.json
+++ b/apps/comments/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -16,7 +17,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@short-video/shared-utils": "workspace:*",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/monitoring": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/comments/src/app/comments.component.test.ts
+++ b/apps/comments/src/app/comments.component.test.ts
@@ -1,0 +1,9 @@
+import { FormBuilder } from '@angular/forms';
+import { CommentsComponent } from './comments.component';
+
+describe('CommentsComponent', () => {
+  it('should create', () => {
+    const component = new CommentsComponent(new FormBuilder());
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/comments/src/main.ts
+++ b/apps/comments/src/main.ts
@@ -1,1 +1,4 @@
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/apps/feed/jest.config.js
+++ b/apps/feed/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/feed/package.json
+++ b/apps/feed/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -16,7 +17,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@short-video/shared-utils": "workspace:*",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/monitoring": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/feed/src/app/feed.module.test.ts
+++ b/apps/feed/src/app/feed.module.test.ts
@@ -1,0 +1,7 @@
+import { FeedModule } from './feed.module';
+
+describe('FeedModule', () => {
+  it('should be defined', () => {
+    expect(FeedModule).toBeDefined();
+  });
+});

--- a/apps/feed/src/main.ts
+++ b/apps/feed/src/main.ts
@@ -1,1 +1,4 @@
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/apps/host/jest.config.js
+++ b/apps/host/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/host/package.json
+++ b/apps/host/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
     "build": "webpack --config webpack.config.js --mode production",
-    "ssr": "node server.js"
+    "ssr": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -18,6 +19,7 @@
     "@angular/router": "^16.0.0",
     "@short-video/ui-kit": "workspace:*",
     "@short-video/shared-utils": "workspace:*",
+    "@short-video/monitoring": "workspace:*",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/apps/host/src/app/app.module.test.ts
+++ b/apps/host/src/app/app.module.test.ts
@@ -1,0 +1,7 @@
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  it('should be defined', () => {
+    expect(AppModule).toBeDefined();
+  });
+});

--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -1,1 +1,4 @@
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/apps/player/jest.config.js
+++ b/apps/player/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/player/package.json
+++ b/apps/player/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -17,7 +18,8 @@
     "@angular/router": "^16.0.0",
     "hls.js": "^1.4.12",
     "player.js": "^0.1.0",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/monitoring": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/player/src/app/video-player.component.test.ts
+++ b/apps/player/src/app/video-player.component.test.ts
@@ -1,0 +1,10 @@
+import { VideoPlayerComponent } from './video-player.component';
+
+describe('VideoPlayerComponent', () => {
+  it('should toggle mute', () => {
+    const comp = new VideoPlayerComponent();
+    comp.videoRef = { nativeElement: { muted: false } } as any;
+    comp.toggleMute();
+    expect(comp.videoRef.nativeElement.muted).toBe(true);
+  });
+});

--- a/apps/player/src/main.ts
+++ b/apps/player/src/main.ts
@@ -1,2 +1,5 @@
 import './styles.css';
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/apps/profile/jest.config.js
+++ b/apps/profile/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/apps/profile/package.json
+++ b/apps/profile/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development --open",
-    "build": "webpack --config webpack.config.js --mode production"
+    "build": "webpack --config webpack.config.js --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -16,7 +17,8 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "@short-video/shared-utils": "workspace:*",
-    "@short-video/ui-kit": "workspace:*"
+    "@short-video/ui-kit": "workspace:*",
+    "@short-video/monitoring": "workspace:*"
   },
   "devDependencies": {
     "@angular-architects/module-federation": "^16.0.0",

--- a/apps/profile/src/app/profile.module.test.ts
+++ b/apps/profile/src/app/profile.module.test.ts
@@ -1,0 +1,7 @@
+import { ProfileModule } from './profile.module';
+
+describe('ProfileModule', () => {
+  it('should be defined', () => {
+    expect(ProfileModule).toBeDefined();
+  });
+});

--- a/apps/profile/src/main.ts
+++ b/apps/profile/src/main.ts
@@ -1,1 +1,4 @@
-import('./bootstrap').catch(err => console.error(err));
+import { initMonitoring, reportError } from '@short-video/monitoring';
+
+initMonitoring();
+import('./bootstrap').catch(reportError);

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/packages/testing-utils/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@short-video/(.*)$': '<rootDir>/packages/$1/src',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "scripts": {
     "build": "pnpm -r build",
     "start": "pnpm --filter host start",
-    "start:feed": "pnpm --filter feed start"
+    "start:feed": "pnpm --filter feed start",
+    "test": "pnpm -r --if-present test"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0"
   }
 }

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@short-video/monitoring",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@sentry/browser": "^7.73.0",
+    "web-vitals": "^3.4.0"
+  }
+}

--- a/packages/monitoring/src/index.ts
+++ b/packages/monitoring/src/index.ts
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/browser';
+import { getCLS, getFID, getLCP, ReportHandler } from 'web-vitals';
+
+export function initMonitoring() {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN || '',
+    environment: process.env.NODE_ENV || 'development',
+  });
+
+  const report: ReportHandler = metric => {
+    Sentry.captureMessage(`${metric.name}: ${metric.value}`);
+  };
+
+  getCLS(report);
+  getFID(report);
+  getLCP(report);
+}
+
+export function reportError(err: any) {
+  Sentry.captureException(err);
+}

--- a/packages/shared-utils/jest.config.js
+++ b/packages/shared-utils/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config.base');
+module.exports = { ...base, rootDir: __dirname };

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "main": "src/index.ts",
   "sideEffects": false,
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.7",
     "rxjs": "^7.8.1"

--- a/packages/shared-utils/src/analytics.test.ts
+++ b/packages/shared-utils/src/analytics.test.ts
@@ -1,0 +1,12 @@
+import { trackEvent, onEvent, ANALYTICS_EVENTS } from './analytics';
+
+describe('analytics event bus integration', () => {
+  it('should emit and listen to events', () => {
+    const payload = { id: 1 };
+    const handler = jest.fn();
+    const off = onEvent<typeof payload>(ANALYTICS_EVENTS.VIDEO_VIEWED, handler);
+    trackEvent(ANALYTICS_EVENTS.VIDEO_VIEWED, payload);
+    expect(handler).toHaveBeenCalledWith(payload);
+    off();
+  });
+});

--- a/packages/testing-utils/jest.setup.ts
+++ b/packages/testing-utils/jest.setup.ts
@@ -1,0 +1,5 @@
+import { resetEventBus } from './src';
+
+beforeEach(() => {
+  resetEventBus();
+});

--- a/packages/testing-utils/package.json
+++ b/packages/testing-utils/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@short-video/testing-utils",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "private": true
+}

--- a/packages/testing-utils/src/index.ts
+++ b/packages/testing-utils/src/index.ts
@@ -1,0 +1,6 @@
+import { eventBus } from '@short-video/event-bus';
+
+export function resetEventBus() {
+  // Accessing private field for test cleanup purposes
+  (eventBus as any).handlers?.clear?.();
+}


### PR DESCRIPTION
## Summary
- add shared monitoring package hooking Sentry and Web Vitals
- wire monitoring into each micro frontend entrypoint
- introduce Jest tests and shared config across micro FEs

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b52aae52248323b48f5fc14728cdec